### PR TITLE
Feature: 적용 가능 쿠폰 조회

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
+        <!--FeignClient-->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/com/example/book2onandoncouponservice/controller/MemberCouponController.java
+++ b/src/main/java/com/example/book2onandoncouponservice/controller/MemberCouponController.java
@@ -1,8 +1,11 @@
 package com.example.book2onandoncouponservice.controller;
 
+import com.example.book2onandoncouponservice.dto.request.OrderCouponCheckRequestDto;
 import com.example.book2onandoncouponservice.dto.request.UseCouponRequestDto;
 import com.example.book2onandoncouponservice.dto.response.MemberCouponResponseDto;
 import com.example.book2onandoncouponservice.service.MemberCouponService;
+import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -39,5 +42,17 @@ public class MemberCouponController {
         Page<MemberCouponResponseDto> coupons = memberCouponService.getMyCoupon(userId, pageable, status);
 
         return ResponseEntity.ok(coupons);
+    }
+
+    @PostMapping("/usable")
+    public ResponseEntity<List<MemberCouponResponseDto>> getUsableCoupons(
+            @RequestHeader("X-USER-ID") Long userId,
+            @Valid @RequestBody OrderCouponCheckRequestDto requestDto) {
+
+        List<MemberCouponResponseDto> result = memberCouponService.getUsableCoupons(
+                userId,
+                requestDto);
+
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/example/book2onandoncouponservice/dto/request/OrderCouponCheckRequestDto.java
+++ b/src/main/java/com/example/book2onandoncouponservice/dto/request/OrderCouponCheckRequestDto.java
@@ -1,0 +1,18 @@
+package com.example.book2onandoncouponservice.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderCouponCheckRequestDto {
+
+    @NotNull(message = "책ID는 필수입니다.")
+    List<Long> bookIds;
+    @NotNull(message = "회원ID는 필수입니다.")
+    List<Long> categoryIds;
+}

--- a/src/main/java/com/example/book2onandoncouponservice/entity/Coupon.java
+++ b/src/main/java/com/example/book2onandoncouponservice/entity/Coupon.java
@@ -12,15 +12,15 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Table(name = "coupon")
 public class Coupon {
 

--- a/src/main/java/com/example/book2onandoncouponservice/entity/CouponPolicy.java
+++ b/src/main/java/com/example/book2onandoncouponservice/entity/CouponPolicy.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,6 +28,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Table(name = "coupon_policy")
 public class CouponPolicy {
     @Id

--- a/src/main/java/com/example/book2onandoncouponservice/entity/MemberCoupon.java
+++ b/src/main/java/com/example/book2onandoncouponservice/entity/MemberCoupon.java
@@ -17,12 +17,15 @@ import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 //쿠폰 중복 발급 방지를 위해 user_id와 coupon_id를 유니크 키로 설정
 @Table(name = "member_coupon", uniqueConstraints = {

--- a/src/main/java/com/example/book2onandoncouponservice/repository/CouponPolicyRepository.java
+++ b/src/main/java/com/example/book2onandoncouponservice/repository/CouponPolicyRepository.java
@@ -4,6 +4,7 @@ import com.example.book2onandoncouponservice.entity.CouponPolicy;
 import com.example.book2onandoncouponservice.entity.CouponPolicyDiscountType;
 import com.example.book2onandoncouponservice.entity.CouponPolicyStatus;
 import com.example.book2onandoncouponservice.entity.CouponPolicyType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,4 +29,17 @@ public interface CouponPolicyRepository extends JpaRepository<CouponPolicy, Long
             "WHERE cp.couponPolicyType = :type " +
             "AND cp.couponPolicyStatus = 'ACTIVE'")
     Optional<CouponPolicy> findActivePolicyByType(@Param("type") CouponPolicyType type);
+
+
+    // 주문에게서 받은 bookids, categoryIds를 포함하는 쿠폰 정책 조회
+    @Query("SELECT DISTINCT p.couponPolicyId FROM CouponPolicy p " +
+            "LEFT JOIN p.couponPolicyTargetBooks tb " +
+            "LEFT JOIN p.couponPolicyTargetCategories tc " +
+            "WHERE " +
+            "   (tb.bookId IN :bookIds) OR " +           // 도서 일치
+            "   (tc.categoryId IN :categoryIds) OR " +   // 카테고리 일치
+            "   (SIZE(p.couponPolicyTargetBooks) = 0 AND SIZE(p.couponPolicyTargetCategories) = 0)")
+    // 제약 조건이 없는 쿠폰
+    List<Long> findApplicablePolicyIds(@Param("bookIds") List<Long> bookIds,
+                                       @Param("categoryIds") List<Long> categoryIds);
 }

--- a/src/main/java/com/example/book2onandoncouponservice/repository/MemberCouponRepository.java
+++ b/src/main/java/com/example/book2onandoncouponservice/repository/MemberCouponRepository.java
@@ -3,6 +3,7 @@ package com.example.book2onandoncouponservice.repository;
 import com.example.book2onandoncouponservice.entity.MemberCoupon;
 import com.example.book2onandoncouponservice.entity.MemberCouponStatus;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -46,4 +47,18 @@ public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long
             "WHERE mc.memberCouponEndDate < :now " +
             "AND mc.memberCouponStatus = 'NOT_USED'")
     int bulkExpireCoupons(@Param("now") LocalDateTime now);
+
+
+    // 쿠폰 정책 id 리스트로 받아서 정책 id에 해당하는 쿠폰 조회
+    @Query("SELECT mc FROM MemberCoupon mc " +
+            "JOIN FETCH mc.coupon c " +
+            "JOIN FETCH c.couponPolicy cp " + // fetch join으로 정책 정보까지 로딩
+            "WHERE mc.userId = :userId " +
+            "AND mc.memberCouponStatus = 'NOT_USED' " +
+            "AND mc.memberCouponEndDate >= :now " +
+            "AND cp.couponPolicyId IN :policyIds")
+    // 정책 ID 목록에 포함되는지 확인
+    List<MemberCoupon> findUsableCouponsByPolicyIds(@Param("userId") Long userId,
+                                                    @Param("policyIds") List<Long> policyIds,
+                                                    @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/example/book2onandoncouponservice/service/MemberCouponService.java
+++ b/src/main/java/com/example/book2onandoncouponservice/service/MemberCouponService.java
@@ -1,7 +1,9 @@
 package com.example.book2onandoncouponservice.service;
 
 
+import com.example.book2onandoncouponservice.dto.request.OrderCouponCheckRequestDto;
 import com.example.book2onandoncouponservice.dto.response.MemberCouponResponseDto;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,4 +18,6 @@ public interface MemberCouponService {
 
     //쿠폰 사용 취소
     void cancelMemberCoupon(Long orderId);
+
+    List<MemberCouponResponseDto> getUsableCoupons(Long userId, OrderCouponCheckRequestDto requestDto);
 }

--- a/src/test/java/com/example/book2onandoncouponservice/repository/CouponPolicyRepositoryTest.java
+++ b/src/test/java/com/example/book2onandoncouponservice/repository/CouponPolicyRepositoryTest.java
@@ -5,7 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.example.book2onandoncouponservice.entity.CouponPolicy;
 import com.example.book2onandoncouponservice.entity.CouponPolicyDiscountType;
 import com.example.book2onandoncouponservice.entity.CouponPolicyStatus;
+import com.example.book2onandoncouponservice.entity.CouponPolicyTargetBook;
+import com.example.book2onandoncouponservice.entity.CouponPolicyTargetCategory;
 import com.example.book2onandoncouponservice.entity.CouponPolicyType;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,23 +27,40 @@ class CouponPolicyRepositoryTest {
     @Autowired
     private TestEntityManager entityManager;
 
-    // Helper: 더미 정책 생성 및 저장
     private CouponPolicy savePolicy(String name, CouponPolicyType type,
                                     CouponPolicyDiscountType discountType,
                                     CouponPolicyStatus status) {
-        CouponPolicy policy = new CouponPolicy();
-        // (Entity에 @Builder나 Setter가 있다고 가정)
-        // 실제로는 Entity 필드 접근 방식에 맞춰 수정해주세요 (ReflectionTestUtils 사용 가능)
-        // 예시:
-        policy.setCouponPolicyName(name);
-        policy.setCouponPolicyType(type);
-        policy.setCouponPolicyDiscountType(discountType);
-        policy.setCouponPolicyStatus(status);
-        policy.setCouponDiscountValue(1000);
-        policy.setMinPrice(10000);
+        CouponPolicy policy = CouponPolicy.builder()
+                .couponPolicyName(name)
+                .couponPolicyType(type)
+                .couponPolicyDiscountType(discountType)
+                .couponPolicyStatus(status)
+                .couponDiscountValue(1000)  // 테스트용 기본값
+                .minPrice(10000)            // 테스트용 기본값
+                .build();
 
         return entityManager.persist(policy);
     }
+
+    // 타겟 도서 추가 헬퍼
+    private void addTargetBook(CouponPolicy policy, Long bookId) {
+        CouponPolicyTargetBook target = CouponPolicyTargetBook.builder()
+                .couponPolicy(policy)
+                .bookId(bookId)
+                .build();
+        entityManager.persist(target);
+    }
+
+    // 타겟 카테고리 추가 헬퍼
+    private void addTargetCategory(CouponPolicy policy, Long categoryId) {
+        CouponPolicyTargetCategory target = CouponPolicyTargetCategory.builder()
+                .couponPolicy(policy)
+                .categoryId(categoryId)
+                .build();
+        entityManager.persist(target);
+    }
+
+    // --- Tests ---
 
     @Test
     @DisplayName("동적 쿼리 테스트 - 모든 조건 null일 때 전체 조회")
@@ -107,5 +128,70 @@ class CouponPolicyRepositoryTest {
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).getCouponPolicyName()).isEqualTo("Target");
+    }
+
+    @Test
+    @DisplayName("주문 상품(도서, 카테고리)에 적용 가능한 정책 ID 조회")
+    void findApplicablePolicyIds_Test() {
+        // given
+        // 1. 특정 도서(100L) 대상 정책
+        CouponPolicy bookPolicy = savePolicy("Book Target", CouponPolicyType.BOOK, CouponPolicyDiscountType.FIXED,
+                CouponPolicyStatus.ACTIVE);
+        addTargetBook(bookPolicy, 100L);
+
+        // 2. 특정 카테고리(20L) 대상 정책
+        CouponPolicy categoryPolicy = savePolicy("Category Target", CouponPolicyType.BOOK,
+                CouponPolicyDiscountType.FIXED, CouponPolicyStatus.ACTIVE);
+        addTargetCategory(categoryPolicy, 20L);
+
+        // 3. 전체 대상 정책 (타겟 없음)
+        CouponPolicy allPolicy = savePolicy("All Target", CouponPolicyType.WELCOME, CouponPolicyDiscountType.FIXED,
+                CouponPolicyStatus.ACTIVE);
+
+        // 4. 해당 사항 없는 정책 (다른 도서 999L)
+        CouponPolicy otherBookPolicy = savePolicy("Other Book", CouponPolicyType.BOOK, CouponPolicyDiscountType.FIXED,
+                CouponPolicyStatus.ACTIVE);
+        addTargetBook(otherBookPolicy, 999L);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        // 주문: 도서 [100, 200], 카테고리 [10, 20]
+        List<Long> resultIds = couponPolicyRepository.findApplicablePolicyIds(
+                List.of(100L, 200L),
+                List.of(10L, 20L)
+        );
+
+        // then
+        assertThat(resultIds).hasSize(3); // bookPolicy, categoryPolicy, allPolicy
+        assertThat(resultIds).contains(
+                bookPolicy.getCouponPolicyId(),
+                categoryPolicy.getCouponPolicyId(),
+                allPolicy.getCouponPolicyId()
+        );
+        assertThat(resultIds).doesNotContain(otherBookPolicy.getCouponPolicyId());
+    }
+
+    @Test
+    @DisplayName("적용 가능한 정책이 없는 경우 빈 리스트 반환")
+    void findApplicablePolicyIds_EmptyTest() {
+        // given
+        CouponPolicy policy = savePolicy("Specific Book", CouponPolicyType.BOOK, CouponPolicyDiscountType.FIXED,
+                CouponPolicyStatus.ACTIVE);
+        addTargetBook(policy, 999L); // 999번 책만 가능
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        // 주문: 도서 100번
+        List<Long> resultIds = couponPolicyRepository.findApplicablePolicyIds(
+                List.of(100L),
+                Collections.emptyList()
+        );
+
+        // then
+        assertThat(resultIds).isEmpty();
     }
 }

--- a/src/test/java/com/example/book2onandoncouponservice/repository/MemberCouponRepositoryTest.java
+++ b/src/test/java/com/example/book2onandoncouponservice/repository/MemberCouponRepositoryTest.java
@@ -10,6 +10,7 @@ import com.example.book2onandoncouponservice.entity.CouponPolicyType;
 import com.example.book2onandoncouponservice.entity.MemberCoupon;
 import com.example.book2onandoncouponservice.entity.MemberCouponStatus;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
 class MemberCouponRepositoryTest {
@@ -27,44 +29,57 @@ class MemberCouponRepositoryTest {
     @Autowired
     private TestEntityManager entityManager;
 
-    // --- Helper Methods ---
+    // --- Helper Methods (Builder 사용) ---
+
     private CouponPolicy createPolicy(String name) {
-        CouponPolicy p = new CouponPolicy();
-        p.setCouponPolicyName(name);
-        p.setCouponPolicyType(CouponPolicyType.WELCOME);
-        p.setCouponPolicyDiscountType(CouponPolicyDiscountType.FIXED);
-        p.setCouponDiscountValue(1000);
-        p.setCouponPolicyStatus(CouponPolicyStatus.ACTIVE);
-        p.setMinPrice(0);
+        CouponPolicy p = CouponPolicy.builder()
+                .couponPolicyName(name)
+                .couponPolicyType(CouponPolicyType.WELCOME)
+                .couponPolicyDiscountType(CouponPolicyDiscountType.FIXED)
+                .couponDiscountValue(1000)
+                .couponPolicyStatus(CouponPolicyStatus.ACTIVE)
+                .minPrice(0)
+                .build();
         return entityManager.persist(p);
     }
 
     private Coupon createCoupon(CouponPolicy policy) {
-        Coupon c = new Coupon(100, policy);
+        Coupon c = Coupon.builder()
+                .couponPolicy(policy)
+                .couponRemainingQuantity(100) // 필드명: couponRemainingQuantity
+                .build();
         return entityManager.persist(c);
     }
 
     private MemberCoupon createMemberCoupon(Long userId, Coupon coupon, MemberCouponStatus status, Long orderId) {
-        MemberCoupon mc = MemberCoupon.builder()
+        // 기본적으로 유효기간이 30일 남은 쿠폰 생성
+        MemberCoupon.MemberCouponBuilder builder = MemberCoupon.builder()
                 .userId(userId)
                 .coupon(coupon)
-                .issuedDate(LocalDateTime.now())
-                .endDate(LocalDateTime.now().plusDays(30))
-                .build();
+                .memberCouponIssuedDate(LocalDateTime.now()) // 필드명: memberCouponIssuedDate
+                .memberCouponEndDate(LocalDateTime.now().plusDays(30)) // 필드명: memberCouponEndDate
+                .memberCouponStatus(MemberCouponStatus.NOT_USED); // 필드명: memberCouponStatus
 
+        MemberCoupon mc = builder.build();
+
+        // 상태 변경 (비즈니스 메서드 사용)
         if (status == MemberCouponStatus.USED) {
-            mc.use(orderId); // 주문 번호와 함께 사용
+            mc.use(orderId);
         } else if (status == MemberCouponStatus.EXPIRED) {
-            mc.expired();
+            // 만료 처리 (메서드가 없으면 Reflection 사용)
+            // mc.expired();
+            ReflectionTestUtils.setField(mc, "memberCouponStatus", MemberCouponStatus.EXPIRED);
         }
 
         return entityManager.persist(mc);
     }
 
-    // 기존 테스트 1
+    // --- Tests ---
+
     @Test
     @DisplayName("내 쿠폰 조회 - 상태 필터링 및 Fetch Join 확인")
     void findCouponsWithPolicy_StatusTest() {
+        // given
         Long userId = 1L;
 
         CouponPolicy p1 = createPolicy("Policy A");
@@ -77,23 +92,25 @@ class MemberCouponRepositoryTest {
 
         createMemberCoupon(userId, c1, MemberCouponStatus.NOT_USED, null);
         createMemberCoupon(userId, c2, MemberCouponStatus.USED, 100L); // 사용된 쿠폰
-        createMemberCoupon(2L, c3, MemberCouponStatus.NOT_USED, null);
+        createMemberCoupon(2L, c3, MemberCouponStatus.NOT_USED, null); // 다른 유저
 
         entityManager.flush();
         entityManager.clear();
 
+        // when
         Page<MemberCoupon> result = memberCouponRepository.findCouponsWithPolicy(
                 userId, MemberCouponStatus.NOT_USED, PageRequest.of(0, 10));
 
+        // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).getCoupon().getCouponPolicy().getCouponPolicyName()).isEqualTo(
                 "Policy A");
     }
 
-    // 기존 테스트 2
     @Test
     @DisplayName("내 쿠폰 조회 - 전체 조회")
     void findCouponsWithPolicy_AllTest() {
+        // given
         Long userId = 1L;
         CouponPolicy p1 = createPolicy("Policy A");
         CouponPolicy p2 = createPolicy("Policy B");
@@ -106,30 +123,33 @@ class MemberCouponRepositoryTest {
         entityManager.flush();
         entityManager.clear();
 
+        // when
         Page<MemberCoupon> result = memberCouponRepository.findCouponsWithPolicy(
                 userId, null, PageRequest.of(0, 10));
 
+        // then
         assertThat(result.getContent()).hasSize(2);
     }
 
-    // 기존 테스트 3
     @Test
     @DisplayName("쿠폰 중복 발급 여부 확인")
     void existsByUserIdAndCoupon_CouponId_Test() {
+        // given
         Long userId = 1L;
         CouponPolicy p = createPolicy("P");
         Coupon c = createCoupon(p);
 
         createMemberCoupon(userId, c, MemberCouponStatus.NOT_USED, null);
 
+        // when
         boolean exists = memberCouponRepository.existsByUserIdAndCoupon_CouponId(userId, c.getCouponId());
         boolean notExists = memberCouponRepository.existsByUserIdAndCoupon_CouponId(userId, 999L);
 
+        // then
         assertThat(exists).isTrue();
         assertThat(notExists).isFalse();
     }
 
-    // [추가] 주문 ID로 쿠폰 찾기 테스트
     @Test
     @DisplayName("주문 ID로 사용된 쿠폰 찾기")
     void findByOrderId_Test() {
@@ -139,7 +159,7 @@ class MemberCouponRepositoryTest {
         CouponPolicy p = createPolicy("Policy");
         Coupon c = createCoupon(p);
 
-        createMemberCoupon(userId, c, MemberCouponStatus.USED, orderId); // orderId=12345로 사용됨
+        createMemberCoupon(userId, c, MemberCouponStatus.USED, orderId);
 
         entityManager.flush();
         entityManager.clear();
@@ -154,5 +174,73 @@ class MemberCouponRepositoryTest {
         assertThat(result.get().getCoupon().getCouponPolicy().getCouponPolicyName()).isEqualTo("Policy");
 
         assertThat(notFound).isEmpty();
+    }
+
+    @Test
+    @DisplayName("정책 ID 리스트로 사용 가능한 내 쿠폰 조회 (Reverse Lookup 2단계)")
+    void findUsableCouponsByPolicyIds_Test() {
+        // given
+        Long userId = 1L;
+        LocalDateTime now = LocalDateTime.now();
+
+        // 1. 정책 생성 (DB 제약조건 회피를 위해 시나리오별로 별도 정책 생성)
+        CouponPolicy p1 = createPolicy("Policy Valid");   // 유효
+        CouponPolicy p2 = createPolicy("Policy Used");    // 사용됨
+        CouponPolicy p3 = createPolicy("Policy Other");   // 대상 아님
+        CouponPolicy p4 = createPolicy("Policy Expired"); // 만료됨
+
+        // 2. 쿠폰 생성 (1 Policy : 1 Coupon)
+        Coupon c1 = createCoupon(p1);
+        Coupon c2 = createCoupon(p2);
+        Coupon c3 = createCoupon(p3);
+        Coupon c4 = createCoupon(p4);
+
+        // 3. 멤버 쿠폰 발급 및 상태 설정
+
+        // [검색 대상] Policy Valid, 사용안함, 기간 남음 -> 조회되어야 함
+        MemberCoupon validMc = createMemberCoupon(userId, c1, MemberCouponStatus.NOT_USED, null);
+
+        // [제외] Policy Used, 이미 사용함
+        createMemberCoupon(userId, c2, MemberCouponStatus.USED, 100L);
+
+        // [제외] Policy Other, 대상 정책 아님 (쿼리 조건에서 빠질 예정)
+        createMemberCoupon(userId, c3, MemberCouponStatus.NOT_USED, null);
+
+        // [제외] Policy A, 다른 유저
+        createMemberCoupon(2L, c1, MemberCouponStatus.NOT_USED,
+                null); // 주의: c1(p1)은 이미 User1이 가졌으므로 1:N 허용 확인 필요. MemberCoupon 테이블은 (UserId, CouponId)가 유니크하므로 User2는 c1 발급 가능.
+
+        // [제외] Policy Expired, 만료됨 (강제로 날짜를 과거로 설정)
+        MemberCoupon expiredMc = MemberCoupon.builder()
+                .userId(userId)
+                .coupon(c4)
+                .memberCouponIssuedDate(now.minusDays(30))
+                .memberCouponEndDate(now.minusDays(1)) // 어제 날짜로 만료
+                .memberCouponStatus(MemberCouponStatus.NOT_USED)
+                .build();
+        entityManager.persist(expiredMc);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        // "주문 상품에 해당하는 정책이 p1, p2, p4 이다" 라고 가정
+        List<Long> targetPolicyIds = List.of(
+                p1.getCouponPolicyId(),
+                p2.getCouponPolicyId(),
+                p4.getCouponPolicyId()
+        );
+
+        List<MemberCoupon> result = memberCouponRepository.findUsableCouponsByPolicyIds(
+                userId,
+                targetPolicyIds,
+                now
+        );
+
+        // then
+        // 사용 완료된 것(p2)과 만료된 것(p4)은 제외되고, 유효한 것(p1) 하나만 나와야 함
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getMemberCouponId()).isEqualTo(validMc.getMemberCouponId());
+        assertThat(result.get(0).getCoupon().getCouponPolicy().getCouponPolicyName()).isEqualTo("Policy Valid");
     }
 }


### PR DESCRIPTION
## 🔀 PR 개요

변경된 내용이나 주요 작업 내용을 간략히 설명해 주세요.

- 주문 적용 가능 쿠폰 조회 API 구현

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.

- Dto 작성
  - Request DTO: OrderCouponCheckRequestDto (bookIds, categoryIds)

  - Response DTO: MemberCouponResponseDto

- 주문 상품(도서/카테고리)에 해당하는 정책 ID 목록을 먼저 DB에서 조회 (findApplicablePolicyIds).

- 해당 정책 ID를 가진 유저의 쿠폰만 IN 절로 조회 (findUsableCouponsByPolicyIds).

- 적용 가능한 정책이 없을 경우 조기 반환(Early Return)하여 불필요한 쿼리 방지.

- 추가한 부분 Test코드에 추가

- [X] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [ ] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [ ] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

---

## 💡 변경 이유

왜 이 변경이 필요한지, 어떤 문제를 해결하려는 것인지 설명해 주세요.

---

## 🧩 관련 이슈

연결된 이슈 번호를 적어주세요.  
예시:

- Closes #50 

---

## 🧪 테스트 방법

변경 내용을 확인할 수 있는 방법을 단계별로 설명해 주세요.  
코드 블록(```)으로 콘솔 로그나 테스트 코드 결과를 첨부해도 좋습니다.
